### PR TITLE
Remove ert as an extras_requires

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,1 +1,5 @@
 pytest
+# This is a workaround as extras_require can not have a url
+# We can consider reinstating this if we want to have the
+# plugin install ert.
+ensemble-reservoir-tool @ git+https://github.com/equinor/ert

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,6 @@ setup(
     long_description_content_type="text/markdown",
     packages=find_packages(include=["snapwell*"]),
     install_requires=["libecl", "equinor-libres"],
-    extras_require={
-        "ert-hooks": ["ensemble-reservoir-tool @ git+https://github.com/equinor/ert"]
-    },
     entry_points={
         "console_scripts": [
             "snapwell_app=snapwell.snapwell_main:main",

--- a/tox.ini
+++ b/tox.ini
@@ -4,8 +4,8 @@ envlist =
     style
 
 [testenv]
-deps = pytest
-extras = ert-hooks
+deps =
+    -rdev-requirements.txt
 commands = python -m pytest tests
 
 [testenv:style]


### PR DESCRIPTION
We have to do this bacause pypi will not allow us to have urls in requirements. Can be reverted once ert is on pypi.